### PR TITLE
Escape `groups` which is a reserved keyword in recent MySQL servers

### DIFF
--- a/src/Security/User/ContaoUser.php
+++ b/src/Security/User/ContaoUser.php
@@ -241,7 +241,7 @@ class ContaoUser
                     }
                 }
 
-                $set['`groups`'] = serialize($arrGroups);
+                $set[$this->connection->quoteIdentifier('groups')] = serialize($arrGroups);
             }
 
             // Set random password

--- a/src/Security/User/ContaoUser.php
+++ b/src/Security/User/ContaoUser.php
@@ -241,7 +241,7 @@ class ContaoUser
                     }
                 }
 
-                $set['groups'] = serialize($arrGroups);
+                $set['`groups`'] = serialize($arrGroups);
             }
 
             // Set random password


### PR DESCRIPTION
This might cause Problems:

https://dev.mysql.com/doc/refman/8.0/en/keywords.html

We [discovered this in our module](https://github.com/iMi-digital/shibboleth-contao-login-client-bundle/actions/runs/6183041211/job/16783959740#step:7:175) which we are basing on yours and believe this would cause problems here as well:



Thank you for this great module :-)