### PR TITLE
fix server-error-with-login-attempts-filter

### DIFF
--- a/contao/dca/tl_member.php
+++ b/contao/dca/tl_member.php
@@ -15,5 +15,6 @@ declare(strict_types=1);
 use Contao\DataContainer;
 
 // Fields
-$GLOBALS['TL_DCA']['tl_member']['fields']['loginAttempts']['sorting'] = true;
-$GLOBALS['TL_DCA']['tl_member']['fields']['loginAttempts']['flag'] = DataContainer::SORT_DESC;
+// TODO: Uncomment it after field loginAttempts is added again:
+// $GLOBALS['TL_DCA']['tl_member']['fields']['loginAttempts']['sorting'] = true;
+// $GLOBALS['TL_DCA']['tl_member']['fields']['loginAttempts']['flag'] = DataContainer::SORT_DESC;

--- a/contao/dca/tl_user.php
+++ b/contao/dca/tl_user.php
@@ -15,5 +15,6 @@ declare(strict_types=1);
 use Contao\DataContainer;
 
 // Fields
-$GLOBALS['TL_DCA']['tl_user']['fields']['loginAttempts']['sorting'] = true;
-$GLOBALS['TL_DCA']['tl_user']['fields']['loginAttempts']['flag'] = DataContainer::SORT_DESC;
+// TODO: Uncomment it after field loginAttempts is added again:
+// $GLOBALS['TL_DCA']['tl_user']['fields']['loginAttempts']['sorting'] = true;
+// $GLOBALS['TL_DCA']['tl_user']['fields']['loginAttempts']['flag'] = DataContainer::SORT_DESC;


### PR DESCRIPTION
fix: remove the filter loginAttempts for member and user

Otherwise, the internal server error persists and the member/user menu cannot be used again (because filter is saved and cannot be cleared for the logged in backend user)

@markocupic Could you please fix this issue with this pull request?
Thank you and happy 2025!